### PR TITLE
Correctly reset fResult before final checks

### DIFF
--- a/src/verify_authenticode.cc
+++ b/src/verify_authenticode.cc
@@ -180,8 +180,7 @@ BOOL VerifyCertificateChain(LPWSTR lpszFileName, LPWSTR lpszSubjectName, LPWSTR 
 	HCRYPTMSG hMsg = NULL;
 	PCCERT_CONTEXT pCertContext = NULL;
 	PCCERT_CONTEXT pTSCertContext = NULL;
-	BOOL fResult;
-	BOOL fReturn = FALSE;
+	BOOL fResult = FALSE;
 	DWORD dwEncoding, dwContentType, dwFormatType;
 	PCMSG_SIGNER_INFO pSignerInfo = NULL;
 	PCMSG_SIGNER_INFO pCounterSignerInfo = NULL;
@@ -447,6 +446,8 @@ BOOL VerifyCertificateChain(LPWSTR lpszFileName, LPWSTR lpszSubjectName, LPWSTR 
 				GetLastError());
 			__leave;
 		}
+
+		fResult = FALSE;
 
 		printf("\nAuthenticode TS chain verification status:\n");
 		if (PolicyStatus.dwError != ERROR_SUCCESS)


### PR DESCRIPTION
We check for false everywhere else, and `__leave` when it is false. Thus returning `fResult = false`.
However in the end when `CertVerifyCertificateChainPolicy` returns `true`, and thus sets fResult to `true`, but then any of the checks on line 452...473 fail, we still return fResult in the end. 

Can alternatively be fixed by making another BOOL variable and just setting that to false by default, and  TRUE on the end of the `try`, and returning that in the end 🤷 

tl:dr
Set false before final checks to prevent `true` returned on a valid signed cert, but not the one we wanted